### PR TITLE
enable https

### DIFF
--- a/src/main/java/org/hl7/davinci/ehrserver/authproxy/PayloadDAOImpl.java
+++ b/src/main/java/org/hl7/davinci/ehrserver/authproxy/PayloadDAOImpl.java
@@ -35,7 +35,7 @@ public class PayloadDAOImpl implements PayloadDAO {
     // create table
     Statement stmt = conn.createStatement();
     try {
-      jdbcTemplate.execute("Create table appcontext (launchId varchar(255) primary key, launchUrl varchar(212) NOT NULL, patient varchar(128) NOT NULL, appContext varchar(8192), launchCode varchar(512), redirectUri varchar(512))");
+      jdbcTemplate.execute("Create table appcontext (launchId varchar(255) primary key, launchUrl varchar(212) NOT NULL, patient varchar(128) NOT NULL, appContext varchar(MAX), launchCode varchar(512), redirectUri varchar(512))");
 
       logger.info("PayloadDAOImpl: AppContext table created in database");
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -122,7 +122,7 @@ server:
   ssl:
     key-store-type: ${EHR_KEY_STORE_TYPE:jks}
     enabled: ${EHR_SSL_ENABLED:false}
-    key-store: ${EHR_KEY_STORE}
+    key-store: ${EHR_KEY_STORE_PATH}
     key-store-password: ${EHR_KEY_STORE_PASSWORD}
     key-password: ${EHR_KEY_PASSWORD}
     key-alias: ${EHR_KEY_ALIAS}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,10 +37,10 @@ hapi:
     fhir_version: R4
     ### enable to use the ApacheProxyAddressStrategy which uses X-Forwarded-* headers
     ### to determine the FHIR server address
-    #   use_apache_address_strategy: false
+    use_apache_address_strategy: ${EHR_SSL_ENABLED:false}
     ### forces the use of the https:// protocol for the returned server address.
     ### alternatively, it may be set using the X-Forwarded-Proto header.
-    #   use_apache_address_strategy_https: false
+    use_apache_address_strategy_https: ${EHR_SSL_ENABLED:false}
     ### enable to set the Server URL
     #    server_address: http://hapi.fhir.org/baseR4
     #    defer_indexing_for_codesystems_of_size: 101
@@ -118,6 +118,14 @@ hapi:
         server_address: "http://hapi.fhir.org/baseR4"
         refuse_to_fetch_third_party_urls: false
         fhir_version: R4
+server:
+  ssl:
+    key-store-type: ${EHR_KEY_STORE_TYPE:jks}
+    enabled: ${EHR_SSL_ENABLED:false}
+    key-store: ${EHR_KEY_STORE}
+    key-store-password: ${EHR_KEY_STORE_PASSWORD}
+    key-password: ${EHR_KEY_PASSWORD}
+    key-alias: ${EHR_KEY_ALIAS}
 #    validation:
 #      requests_enabled: true
 #      responses_enabled: true


### PR DESCRIPTION
Enables https through setting environment variables. If you're in intelliJ, use the `run -> edit configurations` menu option to set environment variables easily for local testing.

This will require a certificate, I use a self-signed jks cert using keytool for local testing.

To try this out, you will need to set the following environment variables:

`EHR_SSL_ENABLED` defaults to false, needs to be true to use https.
`EHR_KEY_STORE_TYPE` defaults to `jks` but can also be `pkcs12` if using a PKCS12 keystore
`EHR_KEY_STORE_PATH` the path to the keystore file
`EHR_KEY_STORE_PASSWORD` the password for the keystore
`EHR_KEY_PASSWORD` the password for the key
`EHR_KEY_ALIAS` the alias of the key

Once all these env variables are set, the test-ehr should launch and you can make a request using https, albeit if you use a self-signed cert you will have to get past the warning telling you that the cert is self-signed.

I'll also note that I ran into some issues using a `pkcs12` key.  As far as I could tell, it was related to the version of java we're using.  But I'm not 100% sure. 