### PR TITLE
Increase Access Token timeout

### DIFF
--- a/src/main/resources/ClientFhirServerRealm.json
+++ b/src/main/resources/ClientFhirServerRealm.json
@@ -5,7 +5,7 @@
   "defaultSignatureAlgorithm" : "RS256",
   "revokeRefreshToken" : false,
   "refreshTokenMaxReuse" : 0,
-  "accessTokenLifespan" : 300,
+  "accessTokenLifespan" : 1800,
   "accessTokenLifespanForImplicitFlow" : 900,
   "ssoSessionIdleTimeout" : 1800,
   "ssoSessionMaxLifespan" : 36000,


### PR DESCRIPTION
Increase the Access Token timeout from 5 to 30 minutes.

Fixes issue [REMS-476](https://jira.mitre.org/browse/REMS-476)